### PR TITLE
Add functionality for opening self-servicing apps for major OS upgrade workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following operating system and versions have been tested.
 Essentially every component of the UI is customizable, all through a JSON configuration file. An [example file](/example_config.json) is available within the code repository.
 
 ### Defined config file
-To define a configuration file, use the `jsonurl` script parameter.  
+To define a configuration file, use the `jsonurl` script parameter.
 ```bash
 --jsonurl=https://fake.domain.com/path/to/config.json
 ```
@@ -81,6 +81,28 @@ This is the second set of text above the **Update Machine** button.
 ```json
 "button_sub_titletext": "Click on the button below."
 ```
+
+### URL for self-servicing upgrade app
+This is the full URL for a local self-servicing app such as Jamf Self
+Service or Munki Managed Software Center linking directly to a Jamf
+policy or Munki catalog item to install a major version upgrade.
+
+This is useful in situations where users do not have administrative
+privileges and cannot run `Install macOS...app` directly.
+
+Provide a full URL with the correct protocol for your self-servicing
+app.
+
+- Open Jamf Self Service to main page: `jamfselfservice://content`
+- Open Jamf Self Service to view a policy by ID number: `jamfselfservice://content?entity=policy&id=<id>&action=view`
+- Open Jamf Self Service to execute a policy by ID number: `jamfselfservice://content?entity=policy&id=<id>&action=execute`
+- Open Manage Software Center to the detail page for an item: `munki://detail-<item name>`
+
+```json
+"local_url_for_upgrade": "jamfselfservice://content?entity=policy&id=<id>&action=view"
+```
+
+Note: If `local_url_for_upgrade` is provided, `path_to_app` is **ignored**.
 
 ### Minimum OS Version
 This is the minimum OS version a machine must be on to not receive this UI.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Service or Munki Managed Software Center linking directly to a Jamf
 policy or Munki catalog item to install a major version upgrade.
 
 This is useful in situations where users do not have administrative
-privileges and cannot run `Install macOS...app` directly.
+privileges and cannot run `Install macOS...app` directly. This option
+has no effect on minor version _updates_ – only full version OS upgrades.
 
 Provide a full URL with the correct protocol for your self-servicing
 app.
@@ -102,7 +103,8 @@ app.
 "local_url_for_upgrade": "jamfselfservice://content?entity=policy&id=<id>&action=view"
 ```
 
-Note: If `local_url_for_upgrade` is provided, `path_to_app` is **ignored**.
+Note: If `local_url_for_upgrade` is provided, `path_to_app` is **ignored**
+in the configuration file.
 
 ### Minimum OS Version
 This is the minimum OS version a machine must be on to not receive this UI.
@@ -157,6 +159,8 @@ This is the path to the macOS installer application.
 ```json
 "path_to_app": "/Applications/Install macOS High Sierra.app"
 ```
+
+Note: This setting is ignored when `local_url_for_upgrade` is provided.
 
 ### No timer
 Do not attempt to restore the nudge GUI to the front of a user's window.

--- a/payload/Library/Application Support/nudge/Resources/nudge
+++ b/payload/Library/Application Support/nudge/Resources/nudge
@@ -443,12 +443,10 @@ def main():
             # Reassign the global PATH_TO_APP with the specified local
             # upgrade URL
             PATH_TO_APP = LOCAL_URL_FOR_UPGRADE
-        if not os.path.exists(PATH_TO_APP) and not LOCAL_URL_FOR_UPGRADE:
-            # The "Install macOS..." app is not present on the system
-            # AND not alternate self-servicing URL was provided
-            print ('Update application not found and no URL provided'
-                   'for a self servicing app! Exiting...')
-            exit(1)
+        else:
+            if not os.path.exists(PATH_TO_APP)
+                print ('Update application not found! Exiting...')
+                exit(1)
     else:
         # do minor version stuff
         if update_minor:

--- a/payload/Library/Application Support/nudge/Resources/nudge
+++ b/payload/Library/Application Support/nudge/Resources/nudge
@@ -47,8 +47,17 @@ def button_moreinfo():
 
 
 def button_update():
-    '''Start the update process'''
-    cmd = ['/usr/bin/open', PATH_TO_APP]
+    '''Start the update process
+
+    By default the original functionality wherein nudge opens the local
+    Install macOS xxx.app is intact; if provided a URL, however, that
+    URL will be opened instead. The expected format is a complete URL
+    ie. `jamfselfservice://content?entity=policy&id=XXX&action=execute`
+    '''
+    if LOCAL_URL_FOR_UPGRADE:
+        cmd = ['/usr/bin/open', LOCAL_URL_FOR_UPGRADE]
+    else:
+        cmd = ['/usr/bin/open', PATH_TO_APP]
     subprocess.Popen(cmd)
 
 
@@ -304,6 +313,7 @@ def main():
     global NUDGE_PATH
     global MORE_INFO_URL
     global PATH_TO_APP
+    global LOCAL_URL_FOR_UPGRADE
 
     # Figure out the local path of nudge
     NUDGE_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -395,6 +405,7 @@ def main():
     PATH_TO_APP = nudge_prefs.get('path_to_app',
         '/Applications/Install macOS Mojave.app')
     screenshot_path = nudge_prefs.get('screenshot_path', 'update_ss.png')
+    LOCAL_URL_FOR_UPGRADE = nudge_prefs.get('local_url_for_upgrade', False)
     timer_day_1 = nudge_prefs.get('timer_day_1', 600)
     timer_day_3 = nudge_prefs.get('timer_day_3', 7200)
     timer_elapsed = nudge_prefs.get('timer_elapsed', 10)
@@ -438,8 +449,9 @@ def main():
     if LooseVersion(minimum_os_version_major) > get_os_version_major():
         # This is a major upgrade now and needs the app. We shouldn't
         # perform minor updates.
-        if not os.path.exists(PATH_TO_APP):
-            print 'Update application not found! Exiting...'
+        if not os.path.exists(PATH_TO_APP) and not LOCAL_URL_FOR_UPGRADE:
+            print ('Update application not found and no URL provided'
+                   'for a self servicing app! Exiting...')
             exit(1)
     else:
         # do minor version stuff

--- a/payload/Library/Application Support/nudge/Resources/nudge
+++ b/payload/Library/Application Support/nudge/Resources/nudge
@@ -47,17 +47,8 @@ def button_moreinfo():
 
 
 def button_update():
-    '''Start the update process
-
-    By default the original functionality wherein nudge opens the local
-    Install macOS xxx.app is intact; if provided a URL, however, that
-    URL will be opened instead. The expected format is a complete URL
-    ie. `jamfselfservice://content?entity=policy&id=XXX&action=execute`
-    '''
-    if LOCAL_URL_FOR_UPGRADE:
-        cmd = ['/usr/bin/open', LOCAL_URL_FOR_UPGRADE]
-    else:
-        cmd = ['/usr/bin/open', PATH_TO_APP]
+    '''Start the update process'''
+    cmd = ['/usr/bin/open', PATH_TO_APP]
     subprocess.Popen(cmd)
 
 
@@ -313,7 +304,6 @@ def main():
     global NUDGE_PATH
     global MORE_INFO_URL
     global PATH_TO_APP
-    global LOCAL_URL_FOR_UPGRADE
 
     # Figure out the local path of nudge
     NUDGE_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -449,7 +439,13 @@ def main():
     if LooseVersion(minimum_os_version_major) > get_os_version_major():
         # This is a major upgrade now and needs the app. We shouldn't
         # perform minor updates.
+        if LOCAL_URL_FOR_UPGRADE:
+            # Reassign the global PATH_TO_APP with the specified local
+            # upgrade URL
+            PATH_TO_APP = LOCAL_URL_FOR_UPGRADE
         if not os.path.exists(PATH_TO_APP) and not LOCAL_URL_FOR_UPGRADE:
+            # The "Install macOS..." app is not present on the system
+            # AND not alternate self-servicing URL was provided
             print ('Update application not found and no URL provided'
                    'for a self servicing app! Exiting...')
             exit(1)


### PR DESCRIPTION
This PR adds a json config item `local_url_for_upgrade` intended to open a local URL within Jamf Self Service or Munki Managed Software Center (and other compatible management tools) to initiate a major OS upgrade workflow.