### PR TITLE
Remove redundant .plist extension in postinstall script

### DIFF
--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -23,7 +23,7 @@ launch_agent_base_path='Library/LaunchAgents/'
 # Load agent if installing to a running system
 if [[ $3 == "/" ]] ; then
   # Fail the install if the admin forgets to change their paths and they don't exist.
-  if [ ! -e "$3/${launch_agent_base_path}${launch_agent_plist_name}.plist" ]; then
+  if [ ! -e "$3/${launch_agent_base_path}${launch_agent_plist_name}" ]; then
     echo "LaunchAgent missing, exiting"
     exit 1
   fi


### PR DESCRIPTION
`launch_agent_plist_name` is already `com.erikng.nudge.plist`
so `${launch_agent_plist_name}.plist` would be `com.erikng.nudge.plist.plist`

The way the current postinstall script is, it exits with a `LaunchAgent missing, exiting` message.