### PR TITLE
removing decoding for the url for log

### DIFF
--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -351,7 +351,7 @@ def main():
                 # If the file doesn't exist, grab it and wait half a second to save.
                 while not os.path.isfile(json_path):
                     nudgelog(('Starting download: %s' % (urllib.parse.unquote(
-                        json_data['url']).decode('utf8'))))
+                        json_data['url']))))
                     downloadfile(json_data)
                     time.sleep(0.5)
         else:


### PR DESCRIPTION
`.decode` was throwing an error on the url string. The `urllib.parse.unquote` seems to handle decoding strings fine on its own.