### PR TITLE
Remove redundant .plist extension in postinstall script

### DIFF
--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -51,6 +51,6 @@ if [[ $3 == "/" ]] ; then
       /bin/launchctl asuser "${console_user_uid}" /bin/launchctl unload "${launch_agent_plist_name}"
     fi
     # Load the launch agent
-    /bin/launchctl asuser "${console_user_uid}" /bin/launchctl load "$3${launch_agent_base_path}${launch_agent_plist_name}.plist"
+    /bin/launchctl asuser "${console_user_uid}" /bin/launchctl load "$3${launch_agent_base_path}${launch_agent_plist_name}"
   fi
 fi


### PR DESCRIPTION
Caught the earlier one but didn't catch this last one at the end of the postinstall script.