### PR TITLE
Convert difference.days to string before logging

### DIFF
--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -522,7 +522,7 @@ def main():
                         today = datetime.utcnow()
                         last_seen_strp = datetime.strptime(last_seen, '%Y-%m-%d %H:%M:%S +0000')
                         difference = today - last_seen_strp
-                        nudgelog(difference.days)
+                        nudgelog(str(difference.days))
                         if difference.days < days_between_notifications:
                             nudgelog('Last seen date is within notification threshold: %s ' % str(days_between_notifications))
                             exit(0)


### PR DESCRIPTION
Otherwise, this error pops up:
```
Traceback (most recent call last):
  File "/Library/nudge/Resources/nudge", line 701, in <module>
    main()
  File "/Library/nudge/Resources/nudge", line 525, in main
    nudgelog(difference.days)
  File "/Library/nudge/Resources/nudge", line 202, in nudgelog
    Foundation.NSLog('[Nudge] ' + text)
TypeError: can only concatenate str (not "int") to str
```