### PR TITLE
Set last_seen even if not blank

### DIFF
--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -531,10 +531,6 @@ def main():
                     set_pref('first_seen', datetime.utcnow())
                     first_seen = pref('first_seen')
 
-                # Set last_seen pref to be now
-                set_pref('last_seen', datetime.utcnow())
-                last_seen = pref('last_seen')
-
     load_nudge_globals()
 
     # Use the paths defined, or default to pngs in the same local path of
@@ -687,6 +683,10 @@ def main():
         nudge.timer.invalidate()
         nudgelog('Timer invalidated!')
     else:
+        # Set last_seen pref to be now
+        set_pref('last_seen', datetime.utcnow())
+        last_seen = pref('last_seen')
+
         nudgelog('Timer is set to %s' % str(timer))
 
     # Set up our window controller and delegate

--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -531,10 +531,9 @@ def main():
                     set_pref('first_seen', datetime.utcnow())
                     first_seen = pref('first_seen')
 
-                if not last_seen:
-                    # we've not nagged recently
-                    set_pref('last_seen', datetime.utcnow())
-                    last_seen = pref('last_seen')
+                # Set last_seen pref to be now
+                set_pref('last_seen', datetime.utcnow())
+                last_seen = pref('last_seen')
 
     load_nudge_globals()
 


### PR DESCRIPTION
The code as it's written now will never update `last_seen` unless it's blank. So it will be set once, and then never updated again. That effectively breaks the `days_between_notification` preference, because the span between `last_seen` and now will get only bigger as time goes by, and so the notifications will keep popping up every half hour.

This PR eliminates the check for whether the `last_seen` pref is blank, and just updates `last_seen` regardless.

Since right before this snippet of code, there is an `exit 0` if the `days_between_notifications` setting is respected, `last_seen` will not be updated if it's been less than the number of days between notifications.