### PR TITLE
Fix for `days_between_notifications`

### DIFF
--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -455,7 +455,7 @@ def main():
     minor_updates_required = False
 
     # Start main logic on major and minor upgrades
-    if LooseVersion(minimum_os_version_major) > os_version_major:
+    if LooseVersion(minimum_os_version_major) > os_version:
         # This is a major upgrade now and needs the app. We shouldn't
         # perform minor updates.
         if LOCAL_URL_FOR_UPGRADE:

--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -690,6 +690,10 @@ def main():
     else:
         nudgelog('Timer is set to %s' % str(timer))
 
+    # Set last_seen to now, regardless of what it was before
+    set_pref('last_seen', datetime.utcnow())
+    last_seen = pref('last_seen')
+    
     # Set up our window controller and delegate
     nudge.hidden = True
     nudge.run()


### PR DESCRIPTION
This fixes it so that if `days_between_notifications` is set, it's also respected.

Two pieces to this are:
1. Using the right comparison variable (`os_version` instead of `os_version_major`)
2. Updating the `last_seen` pref every time the notification window actually appears