### PR TITLE
Account for full_os having one or two dots

### DIFF
--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -131,8 +131,15 @@ def get_os_version():
 def get_os_version_major():
     '''Return major OS version.'''
     full_os = platform.mac_ver()[0]
-    return LooseVersion(full_os.rsplit('.', 1)[0])
-
+    # Sometimes the OS version will return without the dot release
+    # For example, it may show as 10.15.0 instead of 10.15
+    if len(full_os.split('.')) == 3:
+        return LooseVersion(full_os.rsplit('.', 1)[0])
+    elif len(full_os.split('.')) == 2:
+        return LooseVersion(full_os)
+    else:
+        nudgelog('Cannot reliably determine OS major version. Exiting...')
+        exit(1)
 
 def get_parsed_options():
     '''Return the parsed options and args for this application.'''


### PR DESCRIPTION
Sometimes the full_os will show as something like `10.15` or something like `10.15.0`.

`get_os_version_major()` has to account for both scenarios.

Addresses this issue:
https://github.com/erikng/nudge/issues/33