### PR TITLE
Update last_seen pref when showing notification

### DIFF
--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -531,11 +531,6 @@ def main():
                     set_pref('first_seen', datetime.utcnow())
                     first_seen = pref('first_seen')
 
-                if not last_seen:
-                    # we've not nagged recently
-                    set_pref('last_seen', datetime.utcnow())
-                    last_seen = pref('last_seen')
-
     load_nudge_globals()
 
     # Use the paths defined, or default to pngs in the same local path of
@@ -689,6 +684,10 @@ def main():
         nudgelog('Timer invalidated!')
     else:
         nudgelog('Timer is set to %s' % str(timer))
+
+    # Set last_seen pref
+    set_pref('last_seen', datetime.utcnow())
+    last_seen = pref('last_seen')
 
     # Set up our window controller and delegate
     nudge.hidden = True


### PR DESCRIPTION
Right now, `last_seen` gets updated only if it's blank, and then never again.

That's fine for `first_seen`, but `last_seen` should continually update every time the notification window appears; otherwise, the `days_between_notifications` configuration is broken.

Addresses this issue:
https://github.com/erikng/nudge/issues/34