### PR TITLE
Remove --force flag from softwareupdate download

### DIFF
--- a/payload/Library/nudge/Resources/nudge
+++ b/payload/Library/nudge/Resources/nudge
@@ -308,8 +308,7 @@ def download_apple_updates():
 
     cmd = [
         '/usr/sbin/softwareupdate',
-        '-da',
-        '--force'
+        '-da'
     ]
 
     try:


### PR DESCRIPTION
The `--force` flag applies to the `--restart` flag for `--install`, and not for downloading updates, and we're just downloading here.